### PR TITLE
Fix random seed calculation in init module.

### DIFF
--- a/my_project/init.py
+++ b/my_project/init.py
@@ -26,7 +26,7 @@ def main(args, random_seed):
                     r_cut=2.5,
 
                     # random seed
-                    seed=random_seed*replication_index,
+                    seed=random_seed*(replication_index + 1),
 
                     # thermal energy
                     kT=1.0,


### PR DESCRIPTION
By iterating over the replica set with index 0 and multiplying that
index with the seed, all random seeds for the first sets were 0.